### PR TITLE
Fix missed "setcolors" -> "keyfinder-cli" in man page

### DIFF
--- a/keyfinder-cli.1
+++ b/keyfinder-cli.1
@@ -2,7 +2,7 @@
 .SH NAME
 keyfinder-cli \- Estimate the musical key of an audio file
 .SH SYNOPSIS
-\fBsetcolors\fR [-n key-notation] audio-file
+\fBkeyfinder-cli\fR [-n key-notation] audio-file
 .SH DESCRIPTION
 The \fBkeyfinder-cli\fR command is used to estimate the musical key of an audio
 file. Different output key notations are supported. This tool is intended to be


### PR DESCRIPTION
Noticed a trivial oversight while packaging for [Nix](http://nixos.org/).
