### PR TITLE
Call FFmpeg Register Functions to Fix Ubuntu 18.04

### DIFF
--- a/keyfinder_cli.cpp
+++ b/keyfinder_cli.cpp
@@ -84,6 +84,10 @@ void fill_audio_data(const char* file_path, KeyFinder::AudioData &audio)
     static std::once_flag init_flag;
 
     AVFormatContext* format_ctx_ptr = avformat_alloc_context();
+    
+    // Needed for Ubuntu 18.04's versions of ffmpeg (and probably elsewhere?)
+    av_register_all();
+    avcodec_register_all();
 
     // Open the file for decoding
     if (avformat_open_input(&format_ctx_ptr, file_path, nullptr, nullptr) < 0)


### PR DESCRIPTION
I ended up investigating why keyfinder-cli was failing on Ubuntu 18.04.  It'd compile, but running it would produce "Invalid data found when processing input" error from avformat_open_input (after passing it through av_make_error_string--was just returning a negative error code).

Turns out these two function calls are needed before opening file.  I don't' know enough about ffmpeg to know when these requirements were added, or why it's only seeming to affect Ubuntu 18.04 versus i.e. macOS compilation:

av_register_all();
avcodec_register_all();

This fixes Ubuntu 18.04's default repository installs for sure--didn't test other places.