### PR TITLE
Fix endless loop on linux aarch64

### DIFF
--- a/keyfinder_cli.cpp
+++ b/keyfinder_cli.cpp
@@ -265,7 +265,7 @@ int main(int argc, char** argv)
 
     opterr = 0;
 
-    char c;
+    int c;
     while ((c = getopt_long(argc, argv, "n:h", options, nullptr)) != -1)
     {
         switch (c)


### PR DESCRIPTION
Hi,

I ran into a problem while using the tool on an aarch64 linux machine. The parsing of the command line options was stuck in an endless loop.

This patch prevents that the return value of `getopt_long` gets truncated and possibly misinterpreted.

Best regards
