### PR TITLE
Fix linker errors on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CXXFLAGS != pkg-config --cflags --libs fftw3 libavcodec libavformat libavutil li
 all: keyfinder-cli
 
 keyfinder-cli: keyfinder_cli.cpp key_notations.h
-	${CXX} -std=c++11 -Wall ${CXXFLAGS} -o $@ keyfinder_cli.cpp
+	${CXX} keyfinder_cli.cpp -std=c++11 -Wall ${CXXFLAGS} -o $@
 
 install: keyfinder-cli keyfinder-cli.1
 	install -d "${DESTDIR}${PREFIX}/bin"


### PR DESCRIPTION
The previous commit (#25) introduced linker errors on linux (sorry!). 
I have successfully tested this fix on latest Debian, Ubuntu and OpenBSD. 