### PR TITLE
Fix fftw3 package name in github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes \
-            libswresample-dev libavformat-dev libavutil-dev libavcodec-dev fftw3-dev
+            libswresample-dev libavformat-dev libavutil-dev libavcodec-dev libfftw3-dev
 
       - name: Build libkeyfinder
         run: |


### PR DESCRIPTION
Currently, the "Install dependencies" step of the github workflow runs into this error:

```
E: Package 'fftw3-dev' has no installation candidate
Error: Process completed with exit code 100.
```
