### PR TITLE
Fix manpage default install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,4 +28,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE KeyFinder::keyfinder)
 # Installation
 include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME})
-install(FILES ${PROJECT_NAME}.1 TYPE MAN)
+if(UNIX)
+    install(FILES ${PROJECT_NAME}.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+endif()


### PR DESCRIPTION
The manpage should be installed to `${CMAKE_INSTALL_MANDIR}/man1` by default (and only on UNIX systems). 