### PR TITLE
Remove VERSION from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
-project(keyfinder-cli VERSION 1.1.2)
+project(keyfinder-cli)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(${PROJECT_NAME}
-  keyfinder_cli.cpp
+    keyfinder_cli.cpp
 )
 
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
The value for `VERSION` is outdated, but `VERSION` is not used anyway.