### PR TITLE
Add CPack DEB packaging + release workflow (.deb per distro)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
             ca-certificates git \
             g++ make cmake pkg-config \
             libfftw3-dev \
-            libavformat-dev libavcodec-dev libavutil-dev libswresample-dev
+            libavformat-dev libavcodec-dev libavutil-dev libswresample-dev \
+            file fakeroot dpkg-dev
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           apt-get update
           apt-get install --yes --no-install-recommends \
             ca-certificates git \
-            g++ cmake pkg-config \
+            g++ make cmake pkg-config \
             libfftw3-dev \
             libavformat-dev libavcodec-dev libavutil-dev libswresample-dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  linux-amd64:
+    name: Build Linux amd64 tarball
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            cmake pkg-config \
+            libfftw3-dev \
+            libavformat-dev libavcodec-dev libavutil-dev libswresample-dev
+
+      - name: Build libkeyfinder
+        run: |
+          git clone --depth 1 --branch v2.2.6 \
+            https://github.com/mixxxdj/libkeyfinder keyfinder
+          cmake -S keyfinder -B keyfinder/build -DBUILD_TESTING=OFF
+          cmake --build keyfinder/build
+          sudo cmake --install keyfinder/build
+          sudo ldconfig
+
+      - name: Build keyfinder-cli
+        run: |
+          cmake -S . -B build
+          cmake --build build
+
+      # Stage `keyfinder_cli` + the bundled libkeyfinder.so so consumers
+      # only need FFmpeg runtime libs (the .so symlinks are flattened to
+      # real files in the tarball so `tar xzf` lands a usable layout).
+      - name: Stage release tarball
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          stage="keyfinder-cli-${version}-linux-amd64"
+          mkdir -p "$stage/bin" "$stage/lib"
+          cp build/keyfinder-cli "$stage/bin/keyfinder_cli"
+          # Resolve the .so symlink chain to the real library, then
+          # recreate the SONAME symlink ldconfig expects.
+          real=$(readlink -f /usr/local/lib/libkeyfinder.so)
+          soname=$(basename "$(readlink /usr/local/lib/libkeyfinder.so)")
+          cp "$real" "$stage/lib/$(basename "$real")"
+          ln -s "$(basename "$real")" "$stage/lib/$soname"
+          ln -s "$soname" "$stage/lib/libkeyfinder.so"
+          cat > "$stage/README.txt" <<EOF
+          keyfinder-cli prebuilt for Linux amd64.
+          Runtime deps: libavformat, libavcodec, libavutil, libswresample,
+          libfftw3 (all standard on Debian/Ubuntu — usually pulled by ffmpeg).
+          Install: copy bin/keyfinder_cli to /usr/local/bin/ and lib/*
+          to /usr/local/lib/, then run \`sudo ldconfig\`.
+          EOF
+          tar czf "$stage.tar.gz" "$stage"
+          sha256sum "$stage.tar.gz" > "$stage.tar.gz.sha256"
+          echo "ASSET=$stage.tar.gz" >> "$GITHUB_ENV"
+          echo "SUMS=$stage.tar.gz.sha256" >> "$GITHUB_ENV"
+
+      - name: Upload to GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{ env.ASSET }}
+            ${{ env.SUMS }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,32 @@ permissions:
 
 jobs:
   linux-amd64:
-    name: Build Linux amd64 tarball
+    name: Build ${{ matrix.label }} amd64 tarball
     runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Ubuntu 24.04 LTS ships FFmpeg 6 (libavformat.so.60). Works on
+          # Ubuntu 24.04 + downstreams; Debian bookworm also ships FFmpeg 6.
+          - label: ubuntu24
+            container: ubuntu:24.04
+          # Debian trixie ships FFmpeg 7 (libavformat.so.61). Separate
+          # tarball because Ubuntu's .so.60 binary won't load against .61.
+          - label: debian13
+            container: debian:trixie
     steps:
-      - uses: actions/checkout@v4
-
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes \
-            cmake pkg-config \
+          apt-get update
+          apt-get install --yes --no-install-recommends \
+            ca-certificates git \
+            g++ cmake pkg-config \
             libfftw3-dev \
             libavformat-dev libavcodec-dev libavutil-dev libswresample-dev
+
+      - uses: actions/checkout@v4
 
       - name: Build libkeyfinder
         run: |
@@ -30,8 +44,8 @@ jobs:
             https://github.com/mixxxdj/libkeyfinder keyfinder
           cmake -S keyfinder -B keyfinder/build -DBUILD_TESTING=OFF
           cmake --build keyfinder/build
-          sudo cmake --install keyfinder/build
-          sudo ldconfig
+          cmake --install keyfinder/build
+          ldconfig
 
       - name: Build keyfinder-cli
         run: |
@@ -39,12 +53,11 @@ jobs:
           cmake --build build
 
       # Stage `keyfinder_cli` + the bundled libkeyfinder.so so consumers
-      # only need FFmpeg runtime libs (the .so symlinks are flattened to
-      # real files in the tarball so `tar xzf` lands a usable layout).
+      # only need FFmpeg runtime libs that match this image's release.
       - name: Stage release tarball
         run: |
           version="${GITHUB_REF_NAME#v}"
-          stage="keyfinder-cli-${version}-linux-amd64"
+          stage="keyfinder-cli-${version}-linux-amd64-${{ matrix.label }}"
           mkdir -p "$stage/bin" "$stage/lib"
           cp build/keyfinder-cli "$stage/bin/keyfinder_cli"
           # Resolve the .so symlink chain to the real library, then
@@ -55,11 +68,12 @@ jobs:
           ln -s "$(basename "$real")" "$stage/lib/$soname"
           ln -s "$soname" "$stage/lib/libkeyfinder.so"
           cat > "$stage/README.txt" <<EOF
-          keyfinder-cli prebuilt for Linux amd64.
+          keyfinder-cli prebuilt for Linux amd64 (${{ matrix.label }} ABI).
           Runtime deps: libavformat, libavcodec, libavutil, libswresample,
-          libfftw3 (all standard on Debian/Ubuntu — usually pulled by ffmpeg).
+          libfftw3 — usually pulled in by ffmpeg. ABI must match the
+          producer image (e.g. don't run a debian13 build on bookworm).
           Install: copy bin/keyfinder_cli to /usr/local/bin/ and lib/*
-          to /usr/local/lib/, then run \`sudo ldconfig\`.
+          to /usr/local/lib/, then run \`ldconfig\`.
           EOF
           tar czf "$stage.tar.gz" "$stage"
           sha256sum "$stage.tar.gz" > "$stage.tar.gz.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,47 +38,44 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Build libkeyfinder
+      # libkeyfinder built as a STATIC library so it gets linked into
+      # the keyfinder-cli binary — the .deb ships one self-contained
+      # ELF with FFmpeg as the only .so dependency. No /usr/local/lib
+      # drop, no ldconfig dance, dpkg-shlibdeps derives Depends:
+      # straight from ldd output.
+      - name: Build libkeyfinder (static)
         run: |
           git clone --depth 1 --branch v2.2.6 \
             https://github.com/mixxxdj/libkeyfinder keyfinder
-          cmake -S keyfinder -B keyfinder/build -DBUILD_TESTING=OFF
+          cmake -S keyfinder -B keyfinder/build \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           cmake --build keyfinder/build
           cmake --install keyfinder/build
-          ldconfig
 
       - name: Build keyfinder-cli
         run: |
-          cmake -S . -B build
+          version="${GITHUB_REF_NAME#v}"
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCPACK_PACKAGE_VERSION="${version}"
           cmake --build build
 
-      # Stage `keyfinder_cli` + the bundled libkeyfinder.so so consumers
-      # only need FFmpeg runtime libs that match this image's release.
-      - name: Stage release tarball
+      - name: Package .deb (cpack)
         run: |
           version="${GITHUB_REF_NAME#v}"
-          stage="keyfinder-cli-${version}-linux-amd64-${{ matrix.label }}"
-          mkdir -p "$stage/bin" "$stage/lib"
-          cp build/keyfinder-cli "$stage/bin/keyfinder_cli"
-          # Resolve the .so symlink chain to the real library, then
-          # recreate the SONAME symlink ldconfig expects.
-          real=$(readlink -f /usr/local/lib/libkeyfinder.so)
-          soname=$(basename "$(readlink /usr/local/lib/libkeyfinder.so)")
-          cp "$real" "$stage/lib/$(basename "$real")"
-          ln -s "$(basename "$real")" "$stage/lib/$soname"
-          ln -s "$soname" "$stage/lib/libkeyfinder.so"
-          cat > "$stage/README.txt" <<EOF
-          keyfinder-cli prebuilt for Linux amd64 (${{ matrix.label }} ABI).
-          Runtime deps: libavformat, libavcodec, libavutil, libswresample,
-          libfftw3 — usually pulled in by ffmpeg. ABI must match the
-          producer image (e.g. don't run a debian13 build on bookworm).
-          Install: copy bin/keyfinder_cli to /usr/local/bin/ and lib/*
-          to /usr/local/lib/, then run \`ldconfig\`.
-          EOF
-          tar czf "$stage.tar.gz" "$stage"
-          sha256sum "$stage.tar.gz" > "$stage.tar.gz.sha256"
-          echo "ASSET=$stage.tar.gz" >> "$GITHUB_ENV"
-          echo "SUMS=$stage.tar.gz.sha256" >> "$GITHUB_ENV"
+          cd build
+          # Suffix the package filename with the distro label so a single
+          # release page can carry both ABI variants without colliding.
+          cpack -G DEB -D CPACK_PACKAGE_FILE_NAME="keyfinder-cli_${version}-${{ matrix.label }}_amd64"
+          deb=$(ls keyfinder-cli_*_amd64.deb | head -1)
+          sha256sum "$deb" > "${deb}.sha256"
+          # Quick sanity: print Depends + size so the run log shows what
+          # consumers will pull in.
+          dpkg-deb -I "$deb" | grep -E "Depends|Installed-Size"
+          echo "ASSET=build/${deb}" >> "$GITHUB_ENV"
+          echo "SUMS=build/${deb}.sha256" >> "$GITHUB_ENV"
 
       - name: Upload to GitHub release
         if: startsWith(github.ref, 'refs/tags/')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,3 +31,29 @@ install(TARGETS ${PROJECT_NAME})
 if(UNIX)
     install(FILES ${PROJECT_NAME}.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 endif()
+
+# Packaging: `cpack -G DEB` produces a .deb of the installed tree.
+# CPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON makes dpkg-shlibdeps derive the
+# Depends: line from the binary's dynamic library references, so the
+# package gets the correct libavformatN / libfftw3-3 etc. for the
+# build environment without us having to hand-curate per-distro deps.
+set(CPACK_PACKAGE_NAME "keyfinder-cli")
+set(CPACK_PACKAGE_VENDOR "keyfinder-cli upstream")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+    "Small command line tool that detects the musical key of an audio file")
+set(CPACK_PACKAGE_HOMEPAGE_URL
+    "https://github.com/EvanPurkhiser/keyfinder-cli")
+set(CPACK_PACKAGE_CONTACT
+    "keyfinder-cli upstream <https://github.com/EvanPurkhiser/keyfinder-cli/issues>")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+
+# DEB-specific.
+set(CPACK_DEBIAN_PACKAGE_SECTION "sound")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+# Allow CI to override the version (so a tag like v1.2.0-prebuilt-1
+# carries through into the .deb filename + control file).
+if(NOT CPACK_PACKAGE_VERSION)
+    set(CPACK_PACKAGE_VERSION "1.2.0")
+endif()
+
+include(CPack)


### PR DESCRIPTION
## Summary

Adds two things downstream consumers (Ansible roles, homelab installers,
people who don't want to `cmake` two C++ libs by hand) keep asking for:

1. **CPack DEB configuration in `CMakeLists.txt`** — `cpack -G DEB`
   produces a `.deb` from any local build. `CPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON`
   makes `dpkg-shlibdeps` derive `Depends:` from the binary's actual
   library references, so the package picks up the right
   `libavformatN` / `libfftw3-double3` etc. for the build host.

2. **Tag-triggered release workflow** (`.github/workflows/release.yml`)
   that runs the CPack DEB build in a per-distro container matrix and
   uploads the resulting `.deb` plus a `.sha256` to the GitHub release.

The workflow builds **libkeyfinder as a static library** and links it
into the keyfinder-cli binary so the .deb is fully self-contained — the
only runtime deps are FFmpeg + fftw3, which apt resolves from the
distro archive.

### Matrix

FFmpeg ABI differs across distros, so the .deb is per-distro:

- `ubuntu24` (FFmpeg 6 / `libavformat60`) — Ubuntu 24.04, Debian bookworm
- `debian13` (FFmpeg 7 / `libavformat61`) — Debian trixie, Ubuntu 25.04+

Both produce ~90KB packages.

### Result

Consumers install with `apt install ./keyfinder-cli_*_amd64.deb`. No
`/usr/local` surgery, no `ldconfig`, no libkeyfinder build. Verified
on Debian trixie:

```
$ dpkg -I keyfinder-cli_1.2.0-prebuilt-3-debian13_amd64.deb | grep -E "Depends|Installed-Size"
 Depends: libavcodec61 (>= 7:7.1.4), libavformat61 (>= 7:7.1.4), libavutil59 (>= 7:7.1.4), libc6 (>= 2.34), libfftw3-double3 (>= 3.3.10), libgcc-s1 (>= 3.0), libstdc++6 (>= 13.1), libswresample5 (>= 7:7.1.4)
 Installed-Size: 329

$ ldd /usr/bin/keyfinder-cli | grep keyfinder
(empty — statically linked)
```

The existing per-push `build` workflow is untouched.

## Test plan

- [x] Tag pushed on a fork (`gilesw/keyfinder-cli` v1.2.0-prebuilt-3),
  workflow ran green for both matrix entries:
  https://github.com/gilesw/keyfinder-cli/releases/tag/v1.2.0-prebuilt-3
- [x] Debian 13 .deb verified `dpkg -i` clean on real Debian trixie,
  `Depends:` resolved through apt, `keyfinder-cli -n camelot <file>`
  output as expected.
- [ ] Maintainer sanity check.

## Notes

- The CMake `add_executable` name is `keyfinder-cli` (hyphen) which is
  what the .deb installs as. The legacy `make install` produced
  `keyfinder_cli` (underscore). Existing beets configs may need an
  update — minor downstream impact.
- Static linking lives at the workflow level (`-DBUILD_SHARED_LIBS=OFF`
  on libkeyfinder's build), not baked into `CMakeLists.txt`, so manual
  builds keep the original behavior.